### PR TITLE
Deis

### DIFF
--- a/DEIS.env
+++ b/DEIS.env
@@ -1,0 +1,8 @@
+=== joyful-magician Config
+DB_HOST              deis-database.deis
+DB_PASSWORD          [redacted]
+DB_PORT              5432
+DB_USER              pivotal_tasks
+PIVOTAL_API_KEY      [redacted]
+PIVOTAL_PROJECT      1780217
+PORT                 5000

--- a/DEIS.env
+++ b/DEIS.env
@@ -1,8 +1,5 @@
 === joyful-magician Config
-DB_HOST              deis-database.deis
-DB_PASSWORD          [redacted]
-DB_PORT              5432
-DB_USER              pivotal_tasks
+DATABASE_URL         postgres://pivotal_tasks:[redacted]@deis-database.deis.svc.cluster.local/pivotal_tasks_development
 PIVOTAL_API_KEY      [redacted]
 PIVOTAL_PROJECT      1780217
 PORT                 5000

--- a/README.md
+++ b/README.md
@@ -31,10 +31,7 @@ This project is intended to provide a dashboard and GTD interface to tasks.
 * Configuration
     Set environment variables:
 ```
-DB_PASSWORD=secret
-DB_USER=pivotal_tasks_database_user
-DB_HOST=[ip address]
-DB_PORT=5432
+DATABASE_URL=postgres://pivotal_tasks:[secret]@deis-database.deis.svc.cluster.local/[pivotal_tasks_development]
 
 PIVOTAL_API_KEY=00000000000000000000000000000000
 PIVOTAL_PROJECT=k

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ guaranteed and quantified through the API.
 
 This project is intended to provide a dashboard and GTD interface to tasks.
 
-* Ruby version: ruby-2.3.4
+* Ruby version: ruby-2.3.5
 
 * System dependencies:
   * PostgreSQL Database

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -7,4 +7,4 @@ test:
 production:
   adapter: redis
   url: redis://localhost:6379/1
-  channel_prefix: pivotal-tasks_production
+  channel_prefix: pivotal_tasks_production

--- a/config/database.yml
+++ b/config/database.yml
@@ -80,6 +80,4 @@ test:
 #
 production:
   <<: *default
-  database: pivotal_tasks_production
-  username: pivotal_tasks
-  password: <%= ENV['PIVOTAL-TASKS_DATABASE_PASSWORD'] %>
+  url: <%= ENV['DATABASE_URL'] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,25 +23,7 @@ default: &default
 
 development:
   <<: *default
-  database: pivotal_tasks_development
-
-  # The specified database role being used to connect to postgres.
-  # To create additional roles in postgres see `$ createuser --help`.
-  # When left blank, postgres will use the default role. This is
-  # the same name as the operating system user that initialized the database.
-  username: pivotal_tasks
-
-  # The password associated with the postgres role (username).
-  password: <%= ENV.fetch("DB_PASSWORD") %>
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  host: <%= ENV.fetch("DB_HOST") %>
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  port: <%= ENV.fetch("DB_PORT") %>
+  url: <%= ENV['DATABASE_URL'] %>
 
   # Schema search path. The server defaults to $user,public
   #schema_search_path: myapp,sharedapp,public

--- a/config/database.yml
+++ b/config/database.yml
@@ -57,7 +57,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: pivotal-tasks_test
+  database: pivotal_tasks_test
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -80,6 +80,6 @@ test:
 #
 production:
   <<: *default
-  database: pivotal-tasks_production
-  username: pivotal-tasks
+  database: pivotal_tasks_production
+  username: pivotal_tasks
   password: <%= ENV['PIVOTAL-TASKS_DATABASE_PASSWORD'] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,7 +59,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "pivotal-tasks_#{Rails.env}"
+  # config.active_job.queue_name_prefix = "pivotal_tasks_#{Rails.env}"
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pivotal-tasks",
+  "name": "pivotal_tasks",
   "private": true,
   "dependencies": {}
 }


### PR DESCRIPTION
Use Deis for deployment by default (sets RAILS_ENV=production in any environment)

`database.yml`:
```yaml
production:
  <<: *default
  database: pivotal_tasks_production
  username: pivotal_tasks
  password: <%= ENV['PIVOTAL-TASKS_DATABASE_PASSWORD'] %>
```

On Deis/Heroku, this `database.yml` stanza is bad because the `DATABASE_URL` variable will be used instead (...and this is only true some of the time? NB)